### PR TITLE
Refactor routes

### DIFF
--- a/src/handlers/learners/profileLearnersHandler.js
+++ b/src/handlers/learners/profileLearnersHandler.js
@@ -17,7 +17,6 @@ const profileLearnersHandler = async (request, h) => {
     const decoded = JWT.verify(token, secret);
 
     const { learnerId } = decoded; // Mengambil learnerId dari token
-    console.log('Decoded LearnerID:', learnerId);
 
     if (!learnerId) {
       return createResponse(h, 400, 'error', 'Invalid token: learnerId missing');

--- a/src/handlers/mainHandler.js
+++ b/src/handlers/mainHandler.js
@@ -8,14 +8,14 @@ const searchLearnersHandler = require('./tutors/searchLearnersHandler');
 const searchByIdLearnersHandler = require('./tutors/searchByIdLearnersHandler');
 const updateProfileLearnersHandler = require('./learners/updateProfileLearnersHandler');
 const updateProfileTutorsHandler = require('./tutors/updateProfileTutorsHandler');
-const deleteFileTutorHandler = require('./tutors/deleteFileTutorsHandler');
-const transactionHandler = require('./midtrans/transactionsHandler');
+const deleteFileTutorsHandler = require('./tutors/deleteFileTutorsHandler');
+const transactionsHandler = require('./midtrans/transactionsHandler');
 const paymentStatusHandler = require('./midtrans/paymentStatusHandler');
 const { deleteOldPendingPayments } = require('./midtrans/deleteOldPendingPayments');
-const tutorProfileHandler = require('./tutors/profileTutorsHandler');
-const learnerProfileHandler = require('./learners/profileLearnersHandler');
-const tutorsHomeHandler = require('./tutors/homeTutorsHandler');
-const learnersHomeHandler = require('./learners/homeLearnersHandler');
+const profileTutorsHandler = require('./tutors/profileTutorsHandler');
+const profileLearnersHandler = require('./learners/profileLearnersHandler');
+const homeTutorsHandler = require('./tutors/homeTutorsHandler');
+const homeLearnersHandler = require('./learners/homeLearnersHandler');
 
 module.exports = {
   signInHandler,
@@ -28,12 +28,12 @@ module.exports = {
   updateProfileLearnersHandler,
   updateProfileTutorsHandler,
   signOutHandler,
-  deleteFileTutorHandler,
-  transactionHandler,
+  deleteFileTutorsHandler,
+  transactionsHandler,
   paymentStatusHandler,
   deleteOldPendingPayments,
-  tutorProfileHandler,
-  learnerProfileHandler,
-  tutorsHomeHandler,
-  learnersHomeHandler,
+  profileTutorsHandler,
+  profileLearnersHandler,
+  homeTutorsHandler,
+  homeLearnersHandler,
 };

--- a/src/handlers/midtrans/transactionsHandler.js
+++ b/src/handlers/midtrans/transactionsHandler.js
@@ -4,7 +4,7 @@ const createResponse = require('../../createResponse');
 
 const prisma = new PrismaClient();
 
-const transactionHandler = async (request, h) => {
+const transactionsHandler = async (request, h) => {
   const {
     learnerId, tutorId, subject, sessions, price,
   } = request.payload;
@@ -112,4 +112,4 @@ const transactionHandler = async (request, h) => {
   }
 };
 
-module.exports = transactionHandler;
+module.exports = transactionsHandler;

--- a/src/handlers/tutors/deleteFileTutorsHandler.js
+++ b/src/handlers/tutors/deleteFileTutorsHandler.js
@@ -9,7 +9,7 @@ const storage = new Storage({
   keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
 });
 
-const deleteFileTutorHandler = async (request, h) => {
+const deleteFileTutorsHandler = async (request, h) => {
   try {
     const { tutorId } = request.params;
     const { file } = request.query;
@@ -63,4 +63,4 @@ const deleteFileTutorHandler = async (request, h) => {
   }
 };
 
-module.exports = deleteFileTutorHandler;
+module.exports = deleteFileTutorsHandler;

--- a/src/handlers/tutors/deleteFileTutorsHandler.js
+++ b/src/handlers/tutors/deleteFileTutorsHandler.js
@@ -1,22 +1,39 @@
+const JWT = require('jsonwebtoken');
 const { PrismaClient } = require('@prisma/client');
 const { Storage } = require('@google-cloud/storage');
 const createResponse = require('../../createResponse');
 
+const secret = process.env.JWT_SECRET;
 const prisma = new PrismaClient();
 
-const storage = new Storage({
-  projectId: process.env.GOOGLE_PROJECT_ID,
-  keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
-});
+let storage = null;
+
+if (process.env.NODE_ENV !== 'production') {
+  storage = new Storage({
+    projectId: process.env.GOOGLE_PROJECT_ID,
+    keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+  });
+} else {
+  storage = new Storage();
+}
+
+const bucketName = process.env.GOOGLE_BUCKET_NAME;
 
 const deleteFileTutorsHandler = async (request, h) => {
   try {
-    const { tutorId } = request.params;
+    const { authorization } = request.headers;
+    const token = authorization.replace('Bearer ', '');
+    const decoded = JWT.verify(token, secret);
+    const { tutorId } = decoded;
+
+    if (!tutorId) {
+      return createResponse(h, 400, 'error', 'Invalid token: tutorId missing');
+    }
+
     const { file } = request.query;
-    const bucketName = process.env.GOOGLE_BUCKET_NAME;
 
     const tutor = await prisma.tutors.findUnique({
-      where: { id: parseInt(tutorId) },
+      where: { id: tutorId },
     });
 
     if (!tutor) {
@@ -33,7 +50,7 @@ const deleteFileTutorsHandler = async (request, h) => {
       });
 
       await prisma.tutors.update({
-        where: { id: parseInt(tutorId) },
+        where: { id: tutorId },
         data: { cv: null },
       });
 
@@ -50,7 +67,7 @@ const deleteFileTutorsHandler = async (request, h) => {
       });
 
       await prisma.tutors.update({
-        where: { id: parseInt(tutorId) },
+        where: { id: tutorId },
         data: { profile_picture: null },
       });
 

--- a/src/handlers/tutors/homeTutorsHandler.js
+++ b/src/handlers/tutors/homeTutorsHandler.js
@@ -1,14 +1,23 @@
+const JWT = require('jsonwebtoken');
 const { PrismaClient } = require('@prisma/client');
 const createResponse = require('../../createResponse');
 
+const secret = process.env.JWT_SECRET;
 const prisma = new PrismaClient();
 
 const homeTutorsHandler = async (request, h) => {
   try {
-    const { tutorId } = request.params;
+    const { authorization } = request.headers;
+    const token = authorization.replace('Bearer ', '');
+    const decoded = JWT.verify(token, secret);
+    const { tutorId } = decoded;
+
+    if (!tutorId) {
+      return createResponse(h, 400, 'error', 'Invalid token: tutorId missing');
+    }
 
     const tutor = await prisma.tutors.findUnique({
-      where: { id: parseInt(tutorId) },
+      where: { id: tutorId },
       select: {
         id: true,
         user_id: true,

--- a/src/handlers/tutors/profileTutorsHandler.js
+++ b/src/handlers/tutors/profileTutorsHandler.js
@@ -17,7 +17,6 @@ const profileTutorsHandler = async (request, h) => {
     const decoded = JWT.verify(token, secret);
 
     const { tutorId } = decoded; // Mengambil tutorId dari token
-    console.log('Decoded TutorID:', tutorId);
 
     if (!tutorId) {
       return createResponse(h, 400, 'error', 'Invalid token: tutorId missing');

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,13 +7,13 @@ const {
   updateProfileLearnersHandler,
   updateProfileTutorsHandler,
   signOutHandler,
-  deleteFileTutorHandler,
-  transactionHandler,
+  deleteFileTutorsHandler,
+  transactionsHandler,
   paymentStatusHandler,
-  tutorProfileHandler,
-  learnerProfileHandler,
-  tutorsHomeHandler,
-  learnersHomeHandler,
+  profileTutorsHandler,
+  profileLearnersHandler,
+  homeTutorsHandler,
+  homeLearnersHandler,
 } = require('./handlers/mainHandler');
 
 const routes = [
@@ -63,13 +63,13 @@ const routes = [
   },
   {
     method: 'GET',
-    path: '/tutors/{tutorId}/home',
-    handler: tutorsHomeHandler,
+    path: '/tutors/{tutorId}/home', // kaga perlu request parameter
+    handler: homeTutorsHandler,
   },
   {
     method: 'GET',
-    path: '/learners/{learnerId}/home',
-    handler: learnersHomeHandler,
+    path: '/learners/{learnerId}/home', // kaga perlu request parameter
+    handler: homeLearnersHandler,
   },
   {
     // buat nyari tutor nanti di sini ('/tutors')
@@ -87,13 +87,13 @@ const routes = [
   {
     method: 'GET',
     path: '/tutors/my-profile-tutor',
-    handler: tutorProfileHandler,
+    handler: profileTutorsHandler,
   },
   // buat nampilin data learner itu sendiri
   {
     method: 'GET',
     path: '/learners/my-profile-learner',
-    handler: learnerProfileHandler,
+    handler: profileLearnersHandler,
   },
   // untuk melakukan update user dan learner
   {
@@ -131,13 +131,13 @@ const routes = [
   {
     method: 'DELETE',
     path: '/tutors/{tutorId}/profile',
-    handler: deleteFileTutorHandler,
+    handler: deleteFileTutorsHandler,
   },
   // untuk melakukan transaksi
   {
     method: 'POST',
     path: '/transactions',
-    handler: transactionHandler,
+    handler: transactionsHandler,
   },
   // untuk mengecek dan menyimpan status pembayaran
   {

--- a/src/routes.js
+++ b/src/routes.js
@@ -20,7 +20,7 @@ const routes = [
   {
     method: 'GET',
     path: '/',
-    handler: (request, h) => h.response({
+    handler: (h) => h.response({
       status: 'Success',
       message: 'Hello World!',
     }).code(200),
@@ -63,57 +63,42 @@ const routes = [
   },
   {
     method: 'GET',
-    path: '/tutors/{tutorId}/home', // kaga perlu request parameter
+    path: '/tutors/home',
     handler: homeTutorsHandler,
   },
   {
     method: 'GET',
-    path: '/learners/{learnerId}/home', // kaga perlu request parameter
+    path: '/learners/home',
     handler: homeLearnersHandler,
   },
   {
     // buat nyari tutor nanti di sini ('/tutors')
     method: 'GET',
-    path: '/tutors',
+    path: '/tutors/search',
     handler: searchTutorsHandler,
   },
   {
     // buat nampilin data tutor by Id (buat nyari tutor nanti di sini)
     method: 'GET',
-    path: '/tutors/{tutorId}/search',
+    path: '/tutors/search/{tutorId}',
     handler: searchByIdTutorsHandler,
   },
   // buat nampilin data tutor itu sendiri
   {
     method: 'GET',
-    path: '/tutors/my-profile-tutor',
+    path: '/tutors/my-profile',
     handler: profileTutorsHandler,
   },
   // buat nampilin data learner itu sendiri
   {
     method: 'GET',
-    path: '/learners/my-profile-learner',
+    path: '/learners/my-profile',
     handler: profileLearnersHandler,
-  },
-  // untuk melakukan update user dan learner
-  {
-    method: 'PUT',
-    path: '/learners/{id}/profile',
-    options: {
-      payload: {
-        output: 'stream',
-        parse: true,
-        allow: 'multipart/form-data',
-        multipart: true,
-        maxBytes: 2 * 1024 * 1024, // 2 MB limit
-      },
-    },
-    handler: updateProfileLearnersHandler,
   },
   // untuk melakukan update user dan tutor
   {
     method: 'PUT',
-    path: '/tutors/{tutorId}/profile',
+    path: '/tutors/my-profile',
     options: {
       payload: {
         output: 'data', // 'data' untuk menangani JSON, stream bisa tetap untuk multipart
@@ -127,10 +112,16 @@ const routes = [
     },
     handler: updateProfileTutorsHandler,
   },
+  // untuk melakukan update user dan learner
+  {
+    method: 'PUT',
+    path: '/learners/my-profile',
+    handler: updateProfileLearnersHandler,
+  },
   // untuk menghapus file tutor
   {
     method: 'DELETE',
-    path: '/tutors/{tutorId}/profile',
+    path: '/tutors/my-profile',
     handler: deleteFileTutorsHandler,
   },
   // untuk melakukan transaksi


### PR DESCRIPTION
### Mengubah implementasi identifikasi pengguna pada rute-rute yang ada

Sebelumnya identifikasi pengguna dilakukan dengan menggunakan `tutorId` atau `learnerId` pada request parameter seperti `/tutors/{tutorId}/profile`, `/tutors/{tutorId}/home`, atau `/learners/{learnerId}/home`. Sekarang identifikasi dilakukan dengan mendekode token JWT pada header untuk mengambil `tutorId` atau `learnerId`, sehingga penulisan endpoint menjadi lebih sederhana seperti `/tutors/my-profile`, `/learners/my-profile`, `/tutors/home`, dan `/learners/home`.
